### PR TITLE
chore(card column): add card stacking styling

### DIFF
--- a/libs/deckbuilder/shell/src/lib/card-column/card-column.component.html
+++ b/libs/deckbuilder/shell/src/lib/card-column/card-column.component.html
@@ -14,7 +14,7 @@
       <button (click)="removeClick(i)">Remove Card</button>
     </div>
     <div>
-      <img class="card zoom" width="200px" [src]="card.image_uris?.normal" />
+      <img class="card" width="200px" [src]="card.image_uris?.normal" [alt]="card.name" />
     </div>
   </div>
 </div>

--- a/libs/deckbuilder/shell/src/lib/card-column/card-column.component.scss
+++ b/libs/deckbuilder/shell/src/lib/card-column/card-column.component.scss
@@ -1,13 +1,18 @@
+$hover-z-index: 1000000; /* Set this to a ridiculously high number to exceed anything that may be placed in the column. */
+$cdk-drag-preview-z-index: 1000001; /* Set this higher than the hover z-index to prevent weird interactions. */
+
 .list {
-  border: solid 1px #ccc;
-  min-height: 60px;
   background: white;
-  border-radius: 4px;
-  overflow: hidden;
+  border: solid 1px #ccc;
+  border-radius: 4.75% / 3.5%;
   display: block;
+  min-height: 60px;
+  min-width: 200px;
+  overflow: hidden;
 }
 
 .card {
+  border-radius: 4.75% / 3.5%;
   top: 0;
 }
 
@@ -19,6 +24,14 @@
   box-sizing: border-box;
   cursor: move;
   position: relative;
+
+  &:not(:first-child) {
+    margin-top: -250px;
+  }
+
+  &:hover {
+    z-index: $hover-z-index !important;
+  }
 }
 
 .cdk-drag-preview {
@@ -26,6 +39,7 @@
   border-radius: 4px;
   box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
     0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
+  z-index: $cdk-drag-preview-z-index;
 }
 
 .cdk-drag-placeholder {
@@ -42,12 +56,4 @@
 
 .list.cdk-drop-list-dragging .card-box:not(.cdk-drag-placeholder) {
   transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
-}
-
-.zoom {
-  transition: transform .2s; /* Animation */
-}
-
-.zoom:hover {
-  transform: scale(1.5); /* (150% zoom - Note: if the zoom is too large, it will go outside of the viewport) */
 }


### PR DESCRIPTION
- shift up all cards but the first to show the list in a cascading-style view
- change z-index on card hover to pop it over all other cards in the column

Resolves [GitHub Issue #2]